### PR TITLE
Add dynamic presence updates for music activity

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -37,5 +37,6 @@
     "QUEUE_NO_TRACKS": "No tracks in queue",
     "UNKNOWN_TITLE": "Unknown Title",
     "LEFT_EMPTY": "Leaving voice channel because it is empty.",
-    "QUEUE_ENDED": "Leaving voice channel because the queue finished."
+    "QUEUE_ENDED": "Leaving voice channel because the queue finished.",
+    "LISTENING_TO_MUSIC": "music 🎵"
 } 

--- a/locales/es.json
+++ b/locales/es.json
@@ -37,5 +37,6 @@
     "QUEUE_NO_TRACKS": "No hay pistas en la cola",
     "UNKNOWN_TITLE": "Título Desconocido",
     "LEFT_EMPTY": "Abandonando el canal de voz porque está vacío.",
-    "QUEUE_ENDED": "Saliendo del canal de voz porque la lista de reproducción terminó."
+    "QUEUE_ENDED": "Saliendo del canal de voz porque la lista de reproducción terminó.",
+    "LISTENING_TO_MUSIC": "música 🎵"
 } 

--- a/src/events/ready.js
+++ b/src/events/ready.js
@@ -8,7 +8,8 @@ module.exports = {
         await client.lavalink.init({ ...client.user });
         console.log('Lavalink initialized');
         
-        // Set presence
-        client.user.setActivity('música 🎵', { type: 2 }); // Type 2 = LISTENING
+        // Set default presence using translation
+        const defaultPresence = client.t('LISTENING_TO_MUSIC');
+        client.user.setActivity(defaultPresence, { type: 2 }); // Type 2 = LISTENING
     },
 }; 

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -19,6 +19,10 @@ module.exports = {
                 const player = client.lavalink.getPlayer(guildId);
                 if (player) player.destroy();
                 client.playerController.deletePlayer(guildId);
+                
+                // Update presence
+                client.activePlayers.delete(guildId);
+                client.updatePresence();
 
                 // Clear any pending empty-channel disconnect timers
                 if (emptyChannelTimeouts.has(guildId)) {
@@ -70,6 +74,10 @@ module.exports = {
                     const player = client.lavalink.getPlayer(guildId);
                     if (player) player.destroy();
                     client.playerController.deletePlayer(guildId);
+                    
+                    // Update presence
+                    client.activePlayers.delete(guildId);
+                    client.updatePresence();
                 }, timeoutMs);
 
                 emptyChannelTimeouts.set(guildId, timeout);


### PR DESCRIPTION
Introduces presence management to display the current track or a default message when no music is playing. Adds translation keys for the default presence in English and Spanish, and updates presence on relevant Lavalink and voice state events.