### PR TITLE
feature: add song at the top of the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ BeatDock offers 12 comprehensive slash commands organized by category:
 
 | Command | Parameters | Description | Example |
 |---------|------------|-------------|---------|
-| `/play` | `<query>` | Play music from URL or search query | `/play Rick Astley Never Gonna Give You Up` |
+| `/play` | `<query>` `<next>?` | Play music from URL or search query. Optionally, specify whether this song should be appended at the top of the queue | `/play Rick Astley Never Gonna Give You Up` |
 | `/pause` | None | Toggle pause/resume playback | `/pause` |
 | `/skip` | None | Skip to the next track | `/skip` |
 | `/back` | None | Play the previous track from history | `/back` |

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -15,10 +15,15 @@ module.exports = {
         .addStringOption(option =>
             option.setName('query')
                 .setDescription('The song to play (URL or search query).')
-                .setRequired(true)),
+                .setRequired(true))
+        .addBooleanOption(option =>
+            option.setName('next')
+                .setDescription('Add the song to play next in the queue.')
+                .setRequired(false)),
     async execute(interaction) {
         const { client, guild, member, options } = interaction;
         const query = options.getString('query');
+        const playNext = options.getBoolean('next') || false;
         const voiceChannel = member.voice.channel;
         const lang = client.defaultLanguage;
 
@@ -72,7 +77,10 @@ module.exports = {
                 return interaction.editReply({ content: client.languageManager.get(lang, 'NO_RESULTS') });
             }
 
-            player.queue.add(res.loadType === "playlist" ? res.tracks : res.tracks[0]);
+            player.queue.add(
+                res.loadType === "playlist" ? res.tracks : res.tracks[0],
+                playNext ? 0 : undefined
+            );
 
             if (!player.playing) {
                 player.play();


### PR DESCRIPTION
Inspired by other discord music bots, add an optional parameter to `/play` that allows the new song(s) to be added at the top of the queue.
This could be theoretically expanded to allow insertion at arbitrary positions.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add a new next option to the /play command and support inserting the played track at the top of the queue when requested.

### Why are these changes being made?
To allow users to append a requested song to the very front of the queue, enabling immediate playback next. This complements existing behavior by giving control over queue ordering.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->