### PR TITLE
feat: add interactive queue selection with jump-to-track functionality

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -74,5 +74,7 @@
     "LAVALINK_UNAVAILABLE": "❌ Music service is currently unavailable. Please try again in a few moments.",
     "GENERIC_ERROR": "❌ An error occurred while trying to play music. Please try again.",
     "ABOUT_TITLE": "About BeatDock",
-    "ABOUT_DESCRIPTION": "BeatDock is a modern, open-source Discord music bot designed for high-quality audio playback and easy self-hosting."
+    "ABOUT_DESCRIPTION": "BeatDock is a modern, open-source Discord music bot designed for high-quality audio playback and easy self-hosting.",
+    "QUEUE_JUMPED": "▶️ Jumped to **{0}** and removed all previous tracks from the queue.",
+    "QUEUE_JUMP_INVALID": "❌ Invalid track selection. The track may no longer exist in the queue."
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -74,5 +74,7 @@
     "LAVALINK_UNAVAILABLE": "❌ El servicio de música no está disponible en este momento. Por favor, inténtalo de nuevo en unos momentos.",
     "GENERIC_ERROR": "❌ Ocurrió un error al intentar reproducir música. Por favor, inténtalo de nuevo.",
     "ABOUT_TITLE": "Acerca de BeatDock",
-    "ABOUT_DESCRIPTION": "BeatDock es un bot de música para Discord moderno y de código abierto, diseñado para audio de alta calidad y fácil auto-alojamiento."
+    "ABOUT_DESCRIPTION": "BeatDock es un bot de música para Discord moderno y de código abierto, diseñado para audio de alta calidad y fácil auto-alojamiento.",
+    "QUEUE_JUMPED": "▶️ Saltado a **{0}** y eliminadas todas las pistas anteriores de la cola.",
+    "QUEUE_JUMP_INVALID": "❌ Selección de pista inválida. La pista puede que ya no exista en la cola."
 }

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -74,5 +74,7 @@
     "LAVALINK_UNAVAILABLE": "❌ Müzik servisi şu anda kullanılamıyor. Lütfen birkaç dakika sonra tekrar deneyin.",
     "GENERIC_ERROR": "❌ Müzik çalmaya çalışırken bir hata oluştu. Lütfen tekrar deneyin.",
     "ABOUT_TITLE": "BeatDock Hakkında",
-    "ABOUT_DESCRIPTION": "BeatDock, yüksek kaliteli ses çalma ve kolay kendi kendine barındırma için tasarlanmış modern, açık kaynaklı bir Discord müzik botudur."
+    "ABOUT_DESCRIPTION": "BeatDock, yüksek kaliteli ses çalma ve kolay kendi kendine barındırma için tasarlanmış modern, açık kaynaklı bir Discord müzik botudur.",
+    "QUEUE_JUMPED": "▶️ **{0}** şarkısına atlandı ve önceki tüm şarkılar kuyruktan kaldırıldı.",
+    "QUEUE_JUMP_INVALID": "❌ Geçersiz şarkı seçimi. Şarkı artık kuyrukta olmayabilir."
 }


### PR DESCRIPTION
Implemented an interactive queue menu that allows users to select and jump to any song in the queue. When a track is selected, all previous tracks are automatically removed and the selected track starts playing immediately.

## Features
- Added numbered selection buttons (1-10) for each track in the queue
- Buttons display with ▶️ emoji and track number for easy identification
- Supports up to 20 selection buttons per page (Discord's 5-row limit)
- Clicking a button jumps directly to that track and removes all previous tracks
- Maintains existing pagination functionality without conflicts