### PR TITLE
chore: dependency updates and version bump to v2.3.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,7 @@ jobs:
       
     steps:
     - name: Checkout code
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       
     - name: Run Trivy vulnerability scanner
       uses: aquasecurity/trivy-action@master

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <div align="center">
 
-![Version](https://img.shields.io/badge/version-2.2.0-blue?style=flat-square)
+![Version](https://img.shields.io/badge/version-2.3.0-blue?style=flat-square)
 ![License](https://img.shields.io/github/license/lazaroagomez/BeatDock?style=flat-square)
-![Discord.js](https://img.shields.io/badge/discord.js-v14.24.0-blue?style=flat-square)
+![Discord.js](https://img.shields.io/badge/discord.js-v14.25.1-blue?style=flat-square)
 ![Lavalink](https://img.shields.io/badge/Lavalink-v4.1.1-orange?style=flat-square)
 ![Docker](https://img.shields.io/badge/docker-ready-success?style=flat-square)
 ![Node.js](https://img.shields.io/badge/node-%3E%3D22.16.0-green?style=flat-square)

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,7 +36,7 @@
         <div class="container">
             <a class="navbar-brand gaming-font" href="#home">
                 <i class="fas fa-music me-2"></i>
-                <span class="badge bg-primary ms-2">v2.2.0</span>
+                <span class="badge bg-primary ms-2">v2.3.0</span>
             </a>
             <button class="navbar-toggler border-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
                 <span class="navbar-toggler-icon"></span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "beatdock",
-  "version": "2.1.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beatdock",
-      "version": "2.1.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "discord.js": "^14.24.0",
+        "discord.js": "^14.25.1",
         "dotenv": "^17.2.3",
-        "lavalink-client": "^2.6.2"
+        "lavalink-client": "^2.7.0"
       },
       "engines": {
         "node": ">=22.16.0",
@@ -49,12 +49,12 @@
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
-      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "discord-api-types": "^0.38.1"
+        "discord-api-types": "^0.38.33"
       },
       "engines": {
         "node": ">=16.11.0"
@@ -99,10 +99,13 @@
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
-      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
       "license": "Apache-2.0",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
       "engines": {
         "node": ">=18"
       },
@@ -207,28 +210,28 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.38.31",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.31.tgz",
-      "integrity": "sha512-kC94ANsk8ackj8ENTuO8joTNEL0KtymVhHy9dyEC/s4QAZ7GCx40dYEzQaadyo8w+oP0X8QydE/nzAWRylTGtQ==",
+      "version": "0.38.34",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.34.tgz",
+      "integrity": "sha512-muq7xKGznj5MSFCzuIm/2TO7DpttuomUTemVM82fRqgnMl70YRzEyY24jlbiV6R9tzOTq6A6UnZ0bsfZeKD38Q==",
       "license": "MIT",
       "workspaces": [
         "scripts/actions/documentation"
       ]
     },
     "node_modules/discord.js": {
-      "version": "14.24.1",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.24.1.tgz",
-      "integrity": "sha512-LzL+MTGxB9mBwD8FjvkMwcIL4UtgG04e713U3+euqPCvOphhoVEoPpUNTvBPw4iJOas2uiuuh3JcveYSxIn8Tg==",
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@discordjs/builders": "^1.13.0",
         "@discordjs/collection": "1.5.3",
-        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/formatters": "^0.6.2",
         "@discordjs/rest": "^2.6.0",
-        "@discordjs/util": "^1.1.1",
+        "@discordjs/util": "^1.2.0",
         "@discordjs/ws": "^1.2.3",
         "@sapphire/snowflake": "3.5.3",
-        "discord-api-types": "^0.38.31",
+        "discord-api-types": "^0.38.33",
         "fast-deep-equal": "3.1.3",
         "lodash.snakecase": "4.1.1",
         "magic-bytes.js": "^1.10.0",
@@ -261,9 +264,9 @@
       "license": "MIT"
     },
     "node_modules/lavalink-client": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/lavalink-client/-/lavalink-client-2.6.2.tgz",
-      "integrity": "sha512-J1Wrz0YILAI9CDbjrV8B1cEmiI9Pa1eU2OZrAQ6LaOUSsW0bglK47aqOZnzkrmQV4d+ebw99rgKQWKHZnTZCDg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/lavalink-client/-/lavalink-client-2.7.0.tgz",
+      "integrity": "sha512-Q5oJYFDZAsvCCUiNd4xlGExNlUDTstlP6G3lOlxmLuvaXTkMRQW2yeAme72yMiE4tLOA+a13QzWHWDNTVsIiSg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beatdock",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A modern and efficient Discord music bot with slash commands, multi-language support, and Docker deployment.",
   "main": "src/index.js",
   "scripts": {
@@ -38,8 +38,8 @@
     "npm": ">=11.4.2"
   },
   "dependencies": {
-    "discord.js": "^14.24.0",
+    "discord.js": "^14.25.1",
     "dotenv": "^17.2.3",
-    "lavalink-client": "^2.6.2"
+    "lavalink-client": "^2.7.0"
   }
 }


### PR DESCRIPTION
## 📦 Dependency Updates

This PR updates all dependencies flagged by Dependabot to their latest stable versions after comprehensive impact analysis.

### Changes Included

**Dependencies:**
- **discord.js**: `14.24.0` → `14.25.1`
  - Bug fixes for message pinning and GuildMember operations
  - Performance optimizations for role manager cache
  - New features: soundboard, subscriptions (not used by this bot)

- **lavalink-client**: `2.6.2` → `2.7.0`
  - Enhanced track resolution with ISRC matching (improves Spotify accuracy)
  - Robustness improvements with additional null checks
  - Breaking change in `queue.remove()` does not affect our implementation

**CI/CD:**
- **actions/checkout**: `v5` → `v6`
  - Updated credential storage mechanism (no workflow changes required)
  - Compatible with all current workflows

**Version:**
- Bumped BeatDock version: `2.2.0` → `2.3.0`

### Files Modified

- `package.json` & `package-lock.json` - Dependency versions
- `README.md` - Version badges
- `docs/index.html` - Documentation version
- `.github/workflows/*.yml` - Checkout action version


Closes #78, #79, #80