### PR TITLE
feat(search): unify search/queue UI with dropdown menu

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -35,9 +35,9 @@ plugins:
 
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.3"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.16.0"
       snapshot: false
-    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.2.0"
+    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.8.1"
       repository: "https://maven.lavalink.dev/releases"
       snapshot: false
   server:

--- a/locales/en.json
+++ b/locales/en.json
@@ -58,6 +58,7 @@
     "SEARCH_ADD_SELECTED": "Add Selected ({0})",
     "SEARCH_CLEAR_SELECTION": "Clear Selection",
     "SEARCH_CANCEL": "Cancel",
+    "SEARCH_SELECT_PLACEHOLDER": "Select a track to play...",
     "SEARCH_EMPTY_QUERY": "Please provide a search query.",
     "SEARCH_QUERY_TOO_LONG": "Search query is too long. Maximum 200 characters allowed.",
     "SEARCH_SESSION_ERROR": "Failed to create search session. Please try again.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -58,6 +58,7 @@
     "SEARCH_ADD_SELECTED": "Añadir Seleccionados ({0})",
     "SEARCH_CLEAR_SELECTION": "Limpiar Selección",
     "SEARCH_CANCEL": "Cancelar",
+    "SEARCH_SELECT_PLACEHOLDER": "Selecciona una pista para reproducir...",
     "SEARCH_EMPTY_QUERY": "Por favor proporciona una consulta de búsqueda.",
     "SEARCH_QUERY_TOO_LONG": "La consulta de búsqueda es demasiado larga. Máximo 200 caracteres permitidos.",
     "SEARCH_SESSION_ERROR": "Error al crear la sesión de búsqueda. Por favor inténtalo de nuevo.",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -58,6 +58,7 @@
     "SEARCH_ADD_SELECTED": "Seçilenleri Ekle ({0})",
     "SEARCH_CLEAR_SELECTION": "Seçimi Temizle",
     "SEARCH_CANCEL": "İptal",
+    "SEARCH_SELECT_PLACEHOLDER": "Çalmak için bir şarkı seçin...",
     "SEARCH_EMPTY_QUERY": "Lütfen bir arama sorgusu girin.",
     "SEARCH_QUERY_TOO_LONG": "Arama sorgusu çok uzun. Maksimum 200 karakter izin verilir.",
     "SEARCH_SESSION_ERROR": "Arama oturumu oluşturulamadı. Lütfen tekrar deneyin.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beatdock",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beatdock",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "discord.js": "^14.25.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beatdock",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A modern and efficient Discord music bot with slash commands, multi-language support, and Docker deployment.",
   "main": "src/index.js",
   "scripts": {

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -189,7 +189,10 @@ async function handleSelectMenuInteraction(interaction) {
 
         const [component, action] = customId.split(':');
 
-        if (component === 'queue' && action === 'select') {
+        if (component === 'search' && action === 'select') {
+            // Route search dropdown to search navigation handler
+            await handleSearchNavigation(interaction);
+        } else if (component === 'queue' && action === 'select') {
             // Parse selected value: "trackIndex:pageNumber"
             const selectedValue = interaction.values[0];
             const [trackIndexStr, pageStr] = selectedValue.split(':');

--- a/src/utils/searchSessions.js
+++ b/src/utils/searchSessions.js
@@ -37,15 +37,17 @@ class SearchSessionManager {
      * @param {string} guildId - Discord guild ID
      * @param {Array} tracks - Array of track objects from Lavalink
      * @param {string} query - Original search query
+     * @param {string} voiceChannelId - Voice channel ID for deferred player creation
+     * @param {string} textChannelId - Text channel ID for player messages
      * @returns {string} Unique session identifier
      * @throws {Error} If required parameters are missing or invalid
      */
-    createSession(userId, guildId, tracks, query) {
+    createSession(userId, guildId, tracks, query, voiceChannelId, textChannelId) {
         // Use a more robust session ID generation to prevent duplicates
         const timestamp = Date.now();
         const randomSuffix = Math.random().toString(36).substr(2, 9);
         const sessionId = `${userId}-${timestamp}-${randomSuffix}`;
-        
+
         const sessionData = {
             sessionId,
             userId,
@@ -56,7 +58,9 @@ class SearchSessionManager {
             queuedTracks: new Set(), // Track indices that are actually in the queue
             currentPage: 1,
             tracksPerPage: 5,
-            createdAt: Date.now()
+            createdAt: Date.now(),
+            voiceChannelId, // Voice channel for deferred player creation
+            textChannelId,  // Text channel for player messages
         };
 
         this.sessions.set(sessionId, sessionData);

--- a/src/utils/trackSelectMenu.js
+++ b/src/utils/trackSelectMenu.js
@@ -1,0 +1,57 @@
+const { StringSelectMenuBuilder } = require('discord.js');
+
+/**
+ * Truncates text to specified length with ellipsis
+ * @param {string} text - Text to truncate
+ * @param {number} maxLength - Maximum length
+ * @returns {string} Truncated text
+ */
+function truncateText(text, maxLength = 30) {
+    if (!text) return 'Unknown';
+    if (text.length <= maxLength) return text;
+    return text.substring(0, maxLength - 1) + '…';
+}
+
+/**
+ * Creates a track selection dropdown menu
+ * Shared utility used by both /search and /queue commands
+ *
+ * @param {Array} tracks - Array of track objects from Lavalink
+ * @param {Object} options - Configuration options
+ * @param {string} options.customId - Custom ID for the select menu
+ * @param {string} options.placeholder - Placeholder text
+ * @param {number} options.startIndex - Starting index for track numbering
+ * @param {number} options.maxOptions - Maximum options (Discord limit: 25)
+ * @param {Function} options.valueFormatter - Optional custom value formatter (receives globalIndex)
+ * @returns {StringSelectMenuBuilder} Configured select menu
+ */
+function createTrackSelectMenu(tracks, options = {}) {
+    const {
+        customId = 'track:select',
+        placeholder = 'Select a track...',
+        startIndex = 0,
+        maxOptions = 25,
+        valueFormatter = (globalIndex) => `${globalIndex}`,
+    } = options;
+
+    const selectOptions = tracks.slice(0, maxOptions).map((track, index) => {
+        const globalIndex = startIndex + index;
+        const displayNum = globalIndex + 1;
+        const title = truncateText(track.info?.title || 'Unknown', 50);
+        const artist = truncateText(track.info?.author || 'Unknown', 50);
+
+        return {
+            label: `${displayNum}. ${title}`,
+            description: artist.substring(0, 100),
+            value: valueFormatter(globalIndex),
+            emoji: '▶️'
+        };
+    });
+
+    return new StringSelectMenuBuilder()
+        .setCustomId(customId)
+        .setPlaceholder(placeholder)
+        .addOptions(selectOptions);
+}
+
+module.exports = { createTrackSelectMenu, truncateText };


### PR DESCRIPTION
- Replace button-based selection with dropdown menu for /search
- Create shared trackSelectMenu utility for both commands
- Defer player creation until user selects a track
- Add ephemeral search results
- Clean up session after selection
- Create player controller UI when needed

chore(deps): update Lavalink plugins

- youtube-plugin: 1.13.3 → 1.16.0
- lavasrc-plugin: 4.2.0 → 4.8.1

chore: bump version to 2.4.0