### PR TITLE
chore: simplify README and fix docker image reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,424 +1,88 @@
 # BeatDock
 
-<div align="center">
+A Discord music bot powered by Lavalink. Simple to deploy, easy to use.
 
-![Version](https://img.shields.io/badge/version-2.3.0-blue?style=flat-square)
-![License](https://img.shields.io/github/license/lazaroagomez/BeatDock?style=flat-square)
-![Discord.js](https://img.shields.io/badge/discord.js-v14.25.1-blue?style=flat-square)
-![Lavalink](https://img.shields.io/badge/Lavalink-v4.1.1-orange?style=flat-square)
-![Docker](https://img.shields.io/badge/docker-ready-success?style=flat-square)
-![Node.js](https://img.shields.io/badge/node-%3E%3D22.16.0-green?style=flat-square)
+## Quick Start
 
-[🌐 **Live Documentation**](https://lazaroagomez.github.io/BeatDock) • [📥 **Quick Start**](#-quick-start) • [📋 **Commands**](#-commands) • [🐛 **Issues**](https://github.com/lazaroagomez/BeatDock/issues)
+### 1. Setup Discord Bot
 
-</div>
-
-**BeatDock** is a modern, feature-rich Discord music bot built with **Discord.js v14** and powered by **Lavalink**. Designed for simplicity and reliability, it offers high-quality music playback, interactive search capabilities, and seamless Docker deployment.
-
-## ✨ Features
-
-- 🎵 **High-Quality Audio** – Powered by Lavalink for crystal-clear music playback with minimal latency
-- ⚡ **Modern Slash Commands** – Fast, auto-completed slash commands with Discord's latest interaction system
-- 🔍 **Interactive Search** – Advanced search with pagination, multi-selection, and auto-queue management
-- 🌐 **Multi-Language Support** – Built-in support for English, Spanish, and Turkish with easy extensibility
-- 🎮 **Visual Player Controller** – Rich embeds with interactive buttons for playback control
-- 🛡️ **Role-Based Permissions** – Flexible permission system with admin override and role-based access control
-- 🐳 **One-Command Deployment** – Deploy instantly with Docker Compose using pre-built images
-- 📦 **Stateless Design** – No database required; perfect for containerized environments
-- 🎧 **Optional Spotify Integration** – Smart track resolution with ISRC matching for accurate results
-- 🔄 **Advanced Queue Management** – Loop modes, shuffle, history navigation, and queue manipulation
-- 🔊 **Volume Control** – Per-server volume control with validation and persistence
-- ⚙️ **Robust Connection Management** – Advanced Lavalink reconnection with exponential backoff
-
-## 🔒 Prerequisites
-
-### Discord Bot Setup Requirements
-
-> ⚠️ **Critical**: BeatDock requires **all three** Discord Privileged Gateway Intents to function properly.
-
-Before deploying BeatDock, you must enable these intents in your Discord Developer Portal:
-
-1. **✅ Presence Intent** - Required for user presence information
-2. **✅ Server Members Intent** - Required for server member data access  
-3. **✅ Message Content Intent** - Required for message content access
-
-**To enable these intents:**
 1. Go to [Discord Developer Portal](https://discord.com/developers/applications)
-2. Select your bot application → **"Bot"** → **"Privileged Gateway Intents"**
-3. Enable all three toggles → **"Save Changes"**
+2. Create an application and add a bot
+3. Enable **all 3 Privileged Gateway Intents** (Presence, Server Members, Message Content)
+4. Copy the bot token and client ID
 
-> 🚨 **The bot will not start without these intents enabled.**
-
-### System Requirements
-
-- **Node.js**: ≥22.16.0
-- **npm**: ≥11.4.2
-- **Docker**: Latest version (for containerized deployment)
-- **Discord Bot Token** with the above intents enabled
-
-## 🚀 Quick Start
-
-### 1. Clone the Repository
+### 2. Deploy
 
 ```bash
 git clone https://github.com/lazaroagomez/BeatDock.git
 cd BeatDock
 ```
 
-### 2. Configure Environment Variables
-
-Create a `.env` file from the example template:
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` with your bot credentials:
+Create `.env` file with your credentials:
 
 ```env
-# Discord Bot Configuration (Required)
-TOKEN=your_discord_bot_token_here
-CLIENT_ID=your_discord_client_id_here
-
-# Lavalink Configuration (Required for Docker setup)
-LAVALINK_HOST=lavalink
-LAVALINK_PORT=2333
-LAVALINK_PASSWORD=youshallnotpass
-
-# Optional: Spotify Integration
-SPOTIFY_ENABLED=false
-SPOTIFY_CLIENT_ID=your_spotify_client_id_here
-SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
-
-# Optional: Additional Settings
-DEFAULT_LANGUAGE=en
-QUEUE_EMPTY_DESTROY_MS=30000
-EMPTY_CHANNEL_DESTROY_MS=60000
-DEFAULT_VOLUME=80
-ALLOWED_ROLES=
-
-# Optional: Lavalink Reconnection Settings
-LAVALINK_MAX_RECONNECT_ATTEMPTS=10
-LAVALINK_BASE_DELAY_MS=1000
-LAVALINK_MAX_DELAY_MS=30000
-LAVALINK_HEALTH_CHECK_INTERVAL_MS=30000
-LAVALINK_RESET_ATTEMPTS_AFTER_MINUTES=5
+TOKEN=your_discord_bot_token
+CLIENT_ID=your_discord_client_id
 ```
 
-### 3. Deploy with Docker (Recommended)
+Run:
 
 ```bash
-# Deploy slash commands to Discord
 docker compose run --rm bot npm run deploy
-
-# Start the bot and Lavalink server
 docker compose up -d
 ```
 
-### 4. Verify Deployment
+Done. Invite the bot to your server and use `/play`.
 
-```bash
-# Check logs
-docker compose logs -f
+## Commands
 
-# Check running containers
-docker compose ps
+| Command | Description |
+|---------|-------------|
+| `/play <query>` | Play a song |
+| `/search <query>` | Search and select tracks |
+| `/pause` | Pause/resume |
+| `/skip` | Skip track |
+| `/back` | Previous track |
+| `/stop` | Stop and disconnect |
+| `/queue` | Show queue |
+| `/shuffle` | Shuffle queue |
+| `/loop` | Toggle loop mode |
+| `/clear` | Clear queue |
+| `/volume <1-100>` | Set volume |
+| `/nowplaying` | Current track info |
+| `/about` | Bot info |
+
+## Optional Configuration
+
+Add to `.env` if needed:
+
+```env
+# Spotify support
+SPOTIFY_ENABLED=true
+SPOTIFY_CLIENT_ID=your_id
+SPOTIFY_CLIENT_SECRET=your_secret
+
+# Restrict to specific roles (comma-separated IDs)
+ALLOWED_ROLES=123456789,987654321
+
+# Language: en, es, tr
+DEFAULT_LANGUAGE=en
 ```
 
-## 🎵 Commands
-
-BeatDock offers 13 comprehensive slash commands organized by category:
-
-### 🎮 Playback Control
-
-| Command | Parameters | Description | Example |
-|---------|------------|-------------|---------|
-| `/play` | `<query>` | Play music from URL or search query | `/play Rick Astley Never Gonna Give You Up` |
-| `/pause` | None | Toggle pause/resume playback | `/pause` |
-| `/skip` | None | Skip to the next track | `/skip` |
-| `/back` | None | Play the previous track from history | `/back` |
-| `/stop` | None | Stop playback and disconnect from voice | `/stop` |
-| `/volume` | `<level>` (1-100) | Adjust playback volume | `/volume 75` |
-
-### 🔍 Search & Discovery
-
-| Command | Parameters | Description | Example |
-|---------|------------|-------------|---------|
-| `/search` | `<query>` (max 200 chars) | Interactive search with pagination and multi-selection | `/search ambient music` |
-
-### 📋 Queue Management
-
-| Command | Parameters | Description | Example |
-|---------|------------|-------------|---------|
-| `/queue` | None | Display current queue with pagination | `/queue` |
-| `/clear` | None | Clear the entire queue | `/clear` |
-| `/shuffle` | None | Shuffle the current queue | `/shuffle` |
-| `/loop` | None | Cycle through loop modes (off → track → queue) | `/loop` |
-
-### ℹ️ Information
-
-| Command | Parameters | Description | Example |
-|---------|------------|-------------|---------|
-| `/nowplaying` | None | Show detailed info about the current track | `/nowplaying` |
-| `/about` | None | Display bot info, version, stats, uptime, and system details | `/about` |
-
-### 🎛️ Advanced Features
-
-- **Interactive Search**: Use `/search` to browse results with navigation buttons, select multiple tracks, and add them to the queue
-- **Visual Player Controller**: Automatic player interface with buttons for all playbook controls
-- **Loop Modes**: 
-  - `off` - No looping
-  - `track` - Loop current track
-  - `queue` - Loop entire queue
-- **Queue Persistence**: Queue state maintained during voice channel switches
-- **Permission Checks**: All commands respect the role-based permission system
-
-## ⚙️ Setup Guides
-
-### 🐳 Production Deployment (Docker)
-
-The recommended deployment method using the official pre-built image:
-
-#### Prerequisites
-- Docker and Docker Compose installed
-- Discord bot token with required intents
-- Configured `.env` file
-
-#### Deployment Steps
-
-1. **Configure the environment**:
-   ```bash
-   cp .env.example .env
-   # Edit .env with your bot credentials
-   ```
-
-2. **Deploy slash commands**:
-   ```bash
-   docker compose run --rm bot npm run deploy
-   ```
-
-3. **Start services**:
-   ```bash
-   docker compose up -d
-   ```
-
-4. **Monitor logs**:
-   ```bash
-   docker compose logs -f
-   ```
-
-#### Docker Management Commands
+## Useful Commands
 
 ```bash
-# Stop services
-docker compose down
-
-# Restart services  
-docker compose restart
-
-# Update to latest image
-docker compose pull && docker compose up -d
-
-# View logs
-docker compose logs -f bot
-docker compose logs -f lavalink
+docker compose logs -f          # View logs
+docker compose restart          # Restart
+docker compose down             # Stop
+docker compose pull && docker compose up -d  # Update
 ```
 
-### 🛠️ Local Development Setup
+## Links
 
-For development and testing purposes:
+- [Documentation](https://lazaroagomez.github.io/BeatDock)
+- [Issues](https://github.com/lazaroagomez/BeatDock/issues)
 
-#### Prerequisites
-- Node.js ≥22.16.0
-- npm ≥11.4.2
-- Local Lavalink server or Docker for Lavalink only
+## License
 
-#### Setup Steps
-
-1. **Install dependencies**:
-   ```bash
-   npm install
-   ```
-
-2. **Configure environment for local development**:
-   ```env
-   # .env for local development
-   TOKEN=your_discord_bot_token_here
-   CLIENT_ID=your_discord_client_id_here
-   
-   # Point to local Lavalink (if running locally) or Docker Lavalink
-   LAVALINK_HOST=localhost  # or 'lavalink' for Docker
-   LAVALINK_PORT=2333
-   LAVALINK_PASSWORD=youshallnotpass
-   ```
-
-3. **Start Lavalink** (choose one):
-   ```bash
-   # Option A: Use Docker for Lavalink only
-   docker compose up -d lavalink
-   
-   # Option B: Run Lavalink locally (requires Java)
-   # Download Lavalink jar and run with application.yml
-   ```
-
-4. **Deploy commands and start bot**:
-   ```bash
-   npm run deploy
-   npm start
-   ```
-
-### 🔧 Build from Source (Alternative)
-
-If you prefer to build the Docker image yourself:
-
-1. **Modify docker-compose.yml**:
-   ```yaml
-   services:
-     bot:
-       container_name: beatdock
-       build:
-         context: .
-         dockerfile: Dockerfile
-       # Remove the 'image' line
-   ```
-
-2. **Build and deploy**:
-   ```bash
-   docker compose run --rm bot npm run deploy
-   docker compose up -d
-   ```
-
-## 🛡️ Configuration Reference
-
-### Environment Variables
-
-#### Required Variables
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `TOKEN` | Discord bot token from Developer Portal | `MTAx...` |
-| `CLIENT_ID` | Discord application/client ID | `123456789012345678` |
-
-#### Lavalink Configuration
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LAVALINK_HOST` | `lavalink` | Lavalink server hostname |
-| `LAVALINK_PORT` | `2333` | Lavalink server port |
-| `LAVALINK_PASSWORD` | `youshallnotpass` | Lavalink server password |
-
-#### Optional Spotify Integration
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SPOTIFY_ENABLED` | `false` | Enable Spotify track resolution |
-| `SPOTIFY_CLIENT_ID` | - | Spotify application client ID |
-| `SPOTIFY_CLIENT_SECRET` | - | Spotify application client secret |
-
-#### Bot Behavior Settings
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `DEFAULT_LANGUAGE` | `en` | Default language (en/es/tr) |
-| `DEFAULT_VOLUME` | `80` | Default playbook volume (0-100) |
-| `QUEUE_EMPTY_DESTROY_MS` | `30000` | MS to wait before leaving when queue is empty |
-| `EMPTY_CHANNEL_DESTROY_MS` | `60000` | MS to wait before leaving empty voice channel |
-
-#### Permission System
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `ALLOWED_ROLES` | - | Comma-separated role IDs that can use the bot |
-
-**Permission Behavior**:
-- **Empty `ALLOWED_ROLES`**: Everyone can use the bot
-- **Admin Override**: Users with Administrator permission always have access
-- **Role-Based**: Only specified roles can use the bot
-
-**Example**: `ALLOWED_ROLES=123456789012345678,234567890123456789`
-
-#### Advanced Lavalink Settings
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `LAVALINK_MAX_RECONNECT_ATTEMPTS` | `10` | Maximum reconnection attempts |
-| `LAVALINK_BASE_DELAY_MS` | `1000` | Base delay for exponential backoff |
-| `LAVALINK_MAX_DELAY_MS` | `30000` | Maximum delay for reconnection |
-| `LAVALINK_HEALTH_CHECK_INTERVAL_MS` | `30000` | Health check interval |
-| `LAVALINK_RESET_ATTEMPTS_AFTER_MINUTES` | `5` | Reset attempts after N minutes |
-
-## 🔧 Troubleshooting
-
-### Common Issues
-
-#### Bot doesn't respond to commands
-1. **Check Discord Intents**: Ensure all three Privileged Gateway Intents are enabled
-2. **Verify deployment**: Run `docker compose run --rm bot npm run deploy`
-3. **Check permissions**: Ensure the bot has necessary Discord permissions in your server
-
-#### Music doesn't play
-1. **Lavalink connection**: Check `docker compose logs lavalink`
-2. **Voice permissions**: Bot needs Connect and Speak permissions in voice channels
-3. **Firewall**: Ensure port 2333 is accessible for Lavalink
-
-#### Search command not working
-1. **YouTube access**: Ensure your server can access YouTube
-2. **Lavalink plugins**: Verify YouTube plugin is loaded in Lavalink logs
-
-#### Permission errors
-1. **Role configuration**: Check `ALLOWED_ROLES` environment variable
-2. **Admin override**: Remember administrators always have access
-3. **Bot permissions**: Ensure bot has Read Messages/Send Messages permissions
-
-### Getting Help
-
-- **Issues**: [GitHub Issues](https://github.com/lazaroagomez/BeatDock/issues)
-- **Documentation**: [Project Website](https://lazaroagomez.github.io/BeatDock)
-- **Email**: lazaro98@duck.com
-
-When reporting issues, please include:
-- Docker logs: `docker compose logs`
-- Environment: Docker version, OS
-- Error messages: Full error output
-- Steps to reproduce: What you were trying to do
-
-## 🤝 Contributing
-
-We welcome contributions! Please feel free to submit issues, feature requests, or pull requests.
-
-### Development Setup
-
-1. Fork the repository
-2. Follow the [Local Development Setup](#️-local-development-setup)
-3. Make your changes
-4. Test thoroughly
-5. Submit a pull request
-
-### Code Style
-
-- Use ESLint configuration provided
-- Follow existing code patterns
-- Add comments for complex logic
-- Test all changes locally
-
-## 📄 License
-
-This project is licensed under the [Apache-2.0 License](LICENSE).
-
-## 🙏 Acknowledgments
-
-- **Lavalink Team** - For the excellent audio server
-- **Discord.js Contributors** - For the fantastic Discord library
-- **@driftywinds** - For providing ARM64 community image support
-- **[@salvarecuero](https://github.com/salvarecuero)** - For contributions and support
-- **Community Contributors** - For bug reports, suggestions, and improvements
-
----
-
-<div align="center">
-
-**Built with ❤️ for the Discord community**
-
-[⭐ Star this repository](https://github.com/lazaroagomez/BeatDock) • [🐛 Report Bug](https://github.com/lazaroagomez/BeatDock/issues) • [✨ Request Feature](https://github.com/lazaroagomez/BeatDock/issues)
-
-</div>
+[Apache-2.0](LICENSE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   bot:
     container_name: beatdock
-    image: beatdock:latest
+    image: ghcr.io/lazaroagomez/beatdock:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/index.html
+++ b/docs/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -21,7 +22,7 @@
     <nav class="nav">
         <div class="nav-container">
             <a href="#" class="nav-logo">
-                <span class="logo-icon">&#9835;</span>
+                <span class="logo-icon"><i class="bi bi-music-note-beamed"></i></span>
                 <span class="logo-text">BEATDOCK</span>
                 <span class="version-badge" id="version">v2.3.0</span>
             </a>
@@ -31,9 +32,7 @@
                 <a href="#setup" class="nav-link">Setup</a>
                 <a href="#config" class="nav-link">Config</a>
                 <a href="https://github.com/lazaroagomez/BeatDock" target="_blank" rel="noopener" class="nav-link nav-github">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/>
-                    </svg>
+                    <i class="bi bi-github"></i>
                     GitHub
                 </a>
             </div>
@@ -86,7 +85,7 @@
             </div>
             <div class="hero-actions">
                 <a href="#setup" class="btn btn-primary">
-                    <span class="btn-icon">&#9654;</span>
+                    <span class="btn-icon"><i class="bi bi-play-fill"></i></span>
                     Quick Start
                 </a>
                 <a href="https://github.com/lazaroagomez/BeatDock" target="_blank" rel="noopener" class="btn btn-secondary">
@@ -118,11 +117,7 @@
             <div class="features-grid">
                 <div class="feature-card" data-delay="0">
                     <div class="feature-icon">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M9 18V5l12-2v13"/>
-                            <circle cx="6" cy="18" r="3"/>
-                            <circle cx="18" cy="16" r="3"/>
-                        </svg>
+                        <i class="bi bi-soundwave"></i>
                     </div>
                     <h3 class="feature-title">High-Quality Audio</h3>
                     <p class="feature-desc">Crystal-clear playback powered by Lavalink with minimal latency and robust connection management.</p>
@@ -131,10 +126,7 @@
 
                 <div class="feature-card" data-delay="1">
                     <div class="feature-icon icon-search">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="11" cy="11" r="8"/>
-                            <path d="m21 21-4.35-4.35"/>
-                        </svg>
+                        <i class="bi bi-search"></i>
                     </div>
                     <h3 class="feature-title">Interactive Search</h3>
                     <p class="feature-desc">Browse results with navigation buttons, select multiple tracks, and build your perfect queue.</p>
@@ -143,10 +135,7 @@
 
                 <div class="feature-card" data-delay="2">
                     <div class="feature-icon icon-terminal">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <polyline points="4 17 10 11 4 5"/>
-                            <line x1="12" y1="19" x2="20" y2="19"/>
-                        </svg>
+                        <i class="bi bi-terminal"></i>
                     </div>
                     <h3 class="feature-title">Slash Commands</h3>
                     <p class="feature-desc">Modern Discord.js v14 slash commands with auto-completion and parameter validation.</p>
@@ -155,11 +144,7 @@
 
                 <div class="feature-card" data-delay="3">
                     <div class="feature-icon icon-globe">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="12" cy="12" r="10"/>
-                            <line x1="2" y1="12" x2="22" y2="12"/>
-                            <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/>
-                        </svg>
+                        <i class="bi bi-globe"></i>
                     </div>
                     <h3 class="feature-title">Multi-Language</h3>
                     <p class="feature-desc">Built-in support for English, Spanish, and Turkish with easy extensibility.</p>
@@ -168,13 +153,7 @@
 
                 <div class="feature-card" data-delay="4">
                     <div class="feature-icon icon-controller">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <rect x="2" y="6" width="20" height="12" rx="2"/>
-                            <line x1="6" y1="12" x2="10" y2="12"/>
-                            <line x1="8" y1="10" x2="8" y2="14"/>
-                            <circle cx="17" cy="10" r="1"/>
-                            <circle cx="15" cy="13" r="1"/>
-                        </svg>
+                        <i class="bi bi-controller"></i>
                     </div>
                     <h3 class="feature-title">Visual Controller</h3>
                     <p class="feature-desc">Rich embeds with interactive buttons for complete playback control.</p>
@@ -183,12 +162,7 @@
 
                 <div class="feature-card" data-delay="5">
                     <div class="feature-icon icon-docker">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M22 12.5c-.5-1.5-2-2-3.5-2h-1V9h-2v1.5h-2V9h-2v1.5H9V9H7v1.5H5.5c-2 0-3.5 1-4 3 0 0-.5 2 1 4s4 2 4 2h12s3 0 4-2 1-3.5-.5-5z"/>
-                            <rect x="5" y="5" width="2" height="3"/>
-                            <rect x="9" y="5" width="2" height="3"/>
-                            <rect x="9" y="1" width="2" height="3"/>
-                        </svg>
+                        <i class="bi bi-box-seam"></i>
                     </div>
                     <h3 class="feature-title">Docker Ready</h3>
                     <p class="feature-desc">Deploy instantly with Docker Compose using official pre-built images.</p>
@@ -197,10 +171,7 @@
 
                 <div class="feature-card" data-delay="6">
                     <div class="feature-icon icon-shield">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-                            <polyline points="9 12 11 14 15 10"/>
-                        </svg>
+                        <i class="bi bi-shield-check"></i>
                     </div>
                     <h3 class="feature-title">Role Permissions</h3>
                     <p class="feature-desc">Flexible permission system with admin override and role-based access control.</p>
@@ -209,12 +180,7 @@
 
                 <div class="feature-card" data-delay="7">
                     <div class="feature-icon icon-spotify">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="12" cy="12" r="10"/>
-                            <path d="M8 15c3-1 6-1 9 1"/>
-                            <path d="M7 12c4-1.5 8-1.5 12 1"/>
-                            <path d="M6 9c5-2 10-2 15 1"/>
-                        </svg>
+                        <i class="bi bi-spotify"></i>
                     </div>
                     <h3 class="feature-title">Spotify Integration</h3>
                     <p class="feature-desc">Smart track resolution with ISRC matching for accurate Spotify playback.</p>
@@ -223,9 +189,7 @@
 
                 <div class="feature-card" data-delay="8">
                     <div class="feature-icon icon-cloud">
-                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M18 10h-1.26A8 8 0 1 0 9 20h9a5 5 0 0 0 0-10z"/>
-                        </svg>
+                        <i class="bi bi-cloud"></i>
                     </div>
                     <h3 class="feature-title">Stateless Design</h3>
                     <p class="feature-desc">No database required - perfect for containerized deployments.</p>
@@ -248,7 +212,7 @@
                 <!-- Playback Controls -->
                 <div class="command-group">
                     <h3 class="group-title">
-                        <span class="group-icon">&#9654;</span>
+                        <span class="group-icon"><i class="bi bi-play-circle"></i></span>
                         Playback Control
                     </h3>
                     <div class="commands-grid">
@@ -313,7 +277,7 @@
                 <!-- Search & Discovery -->
                 <div class="command-group">
                     <h3 class="group-title">
-                        <span class="group-icon">&#128269;</span>
+                        <span class="group-icon"><i class="bi bi-search"></i></span>
                         Search & Discovery
                     </h3>
                     <div class="commands-grid">
@@ -328,9 +292,9 @@
                                 <code>/search ambient music</code>
                             </div>
                             <div class="command-features">
-                                <span>&#10003; Pagination</span>
-                                <span>&#10003; Multi-select</span>
-                                <span>&#10003; Quick add</span>
+                                <span><i class="bi bi-check"></i> Pagination</span>
+                                <span><i class="bi bi-check"></i> Multi-select</span>
+                                <span><i class="bi bi-check"></i> Quick add</span>
                             </div>
                         </div>
                     </div>
@@ -339,7 +303,7 @@
                 <!-- Queue Management -->
                 <div class="command-group">
                     <h3 class="group-title">
-                        <span class="group-icon">&#128203;</span>
+                        <span class="group-icon"><i class="bi bi-list-ol"></i></span>
                         Queue Management
                     </h3>
                     <div class="commands-grid">
@@ -388,7 +352,7 @@
                 <!-- Information -->
                 <div class="command-group">
                     <h3 class="group-title">
-                        <span class="group-icon">&#8505;</span>
+                        <span class="group-icon"><i class="bi bi-info-circle"></i></span>
                         Information
                     </h3>
                     <div class="commands-grid">
@@ -399,9 +363,9 @@
                             </div>
                             <p class="command-desc">Display bot info, stats, version, and system details</p>
                             <div class="command-features">
-                                <span>&#10003; Version</span>
-                                <span>&#10003; Uptime</span>
-                                <span>&#10003; Latency</span>
+                                <span><i class="bi bi-check"></i> Version</span>
+                                <span><i class="bi bi-check"></i> Uptime</span>
+                                <span><i class="bi bi-check"></i> Latency</span>
                             </div>
                         </div>
                     </div>
@@ -421,14 +385,14 @@
 
             <!-- Prerequisites Warning -->
             <div class="warning-box">
-                <div class="warning-icon">&#9888;</div>
+                <div class="warning-icon"><i class="bi bi-exclamation-triangle"></i></div>
                 <div class="warning-content">
                     <h4>Required: Discord Gateway Intents</h4>
                     <p>Enable these in <a href="https://discord.com/developers/applications" target="_blank" rel="noopener">Discord Developer Portal</a> &rarr; Bot &rarr; Privileged Gateway Intents:</p>
                     <div class="intents-list">
-                        <span class="intent">&#10003; Presence Intent</span>
-                        <span class="intent">&#10003; Server Members Intent</span>
-                        <span class="intent">&#10003; Message Content Intent</span>
+                        <span class="intent"><i class="bi bi-check-lg"></i> Presence Intent</span>
+                        <span class="intent"><i class="bi bi-check-lg"></i> Server Members Intent</span>
+                        <span class="intent"><i class="bi bi-check-lg"></i> Message Content Intent</span>
                     </div>
                 </div>
             </div>
@@ -456,7 +420,7 @@
                                 </div>
                             </div>
                             <button class="copy-btn" data-copy="git clone https://github.com/lazaroagomez/BeatDock.git && cd BeatDock">
-                                <span class="copy-icon">&#128203;</span>
+                                <span class="copy-icon"><i class="bi bi-clipboard"></i></span>
                                 <span class="copy-text">Copy</span>
                             </button>
                         </div>
@@ -498,7 +462,7 @@
                                 </div>
                             </div>
                             <button class="copy-btn" data-copy="cp .env.example .env">
-                                <span class="copy-icon">&#128203;</span>
+                                <span class="copy-icon"><i class="bi bi-clipboard"></i></span>
                                 <span class="copy-text">Copy</span>
                             </button>
                         </div>
@@ -521,10 +485,10 @@
                                     <span class="prompt">$</span>
                                     <span class="command">docker compose run --rm bot npm run deploy</span>
                                 </div>
-                                <div class="terminal-output">&#10003; Successfully registered 12 commands</div>
+                                <div class="terminal-output"><i class="bi bi-check-lg"></i> Successfully registered 12 commands</div>
                             </div>
                             <button class="copy-btn" data-copy="docker compose run --rm bot npm run deploy">
-                                <span class="copy-icon">&#128203;</span>
+                                <span class="copy-icon"><i class="bi bi-clipboard"></i></span>
                                 <span class="copy-text">Copy</span>
                             </button>
                         </div>
@@ -547,10 +511,10 @@
                                     <span class="prompt">$</span>
                                     <span class="command">docker compose up -d</span>
                                 </div>
-                                <div class="terminal-output success">&#9889; BeatDock is now running!</div>
+                                <div class="terminal-output success"><i class="bi bi-lightning-fill"></i> BeatDock is now running!</div>
                             </div>
                             <button class="copy-btn" data-copy="docker compose up -d">
-                                <span class="copy-icon">&#128203;</span>
+                                <span class="copy-icon"><i class="bi bi-clipboard"></i></span>
                                 <span class="copy-text">Copy</span>
                             </button>
                         </div>
@@ -563,22 +527,22 @@
                 <h3 class="docker-title">Docker Quick Reference</h3>
                 <div class="docker-grid">
                     <div class="docker-card">
-                        <span class="docker-icon">&#9632;</span>
+                        <span class="docker-icon"><i class="bi bi-stop-fill"></i></span>
                         <span class="docker-label">Stop</span>
                         <code>docker compose down</code>
                     </div>
                     <div class="docker-card">
-                        <span class="docker-icon">&#8634;</span>
+                        <span class="docker-icon"><i class="bi bi-arrow-clockwise"></i></span>
                         <span class="docker-label">Restart</span>
                         <code>docker compose restart</code>
                     </div>
                     <div class="docker-card">
-                        <span class="docker-icon">&#128196;</span>
+                        <span class="docker-icon"><i class="bi bi-file-text"></i></span>
                         <span class="docker-label">Logs</span>
                         <code>docker compose logs -f</code>
                     </div>
                     <div class="docker-card">
-                        <span class="docker-icon">&#8593;</span>
+                        <span class="docker-icon"><i class="bi bi-arrow-up-circle"></i></span>
                         <span class="docker-label">Update</span>
                         <code>docker compose pull && docker compose up -d</code>
                     </div>
@@ -599,7 +563,7 @@
             <div class="config-container">
                 <div class="config-group">
                     <h3 class="config-group-title">
-                        <span class="config-icon required">&#9733;</span>
+                        <span class="config-icon required"><i class="bi bi-star-fill"></i></span>
                         Required
                     </h3>
                     <div class="config-table">
@@ -616,7 +580,7 @@
 
                 <div class="config-group">
                     <h3 class="config-group-title">
-                        <span class="config-icon">&#9881;</span>
+                        <span class="config-icon"><i class="bi bi-gear"></i></span>
                         Lavalink
                     </h3>
                     <div class="config-table">
@@ -640,7 +604,7 @@
 
                 <div class="config-group">
                     <h3 class="config-group-title">
-                        <span class="config-icon spotify">&#9836;</span>
+                        <span class="config-icon spotify"><i class="bi bi-spotify"></i></span>
                         Spotify (Optional)
                     </h3>
                     <div class="config-table">
@@ -662,7 +626,7 @@
 
                 <div class="config-group">
                     <h3 class="config-group-title">
-                        <span class="config-icon">&#9874;</span>
+                        <span class="config-icon"><i class="bi bi-sliders"></i></span>
                         Bot Behavior
                     </h3>
                     <div class="config-table">
@@ -696,7 +660,7 @@
             </div>
 
             <div class="permission-note">
-                <div class="note-icon">&#128274;</div>
+                <div class="note-icon"><i class="bi bi-lock"></i></div>
                 <div class="note-content">
                     <strong>Permission System:</strong>
                     Empty ALLOWED_ROLES = everyone can use the bot.
@@ -711,7 +675,7 @@
         <div class="container">
             <div class="footer-content">
                 <div class="footer-brand">
-                    <span class="footer-logo">&#9835; BEATDOCK</span>
+                    <span class="footer-logo"><i class="bi bi-music-note-beamed"></i> BEATDOCK</span>
                     <p class="footer-tagline">Drop the beat. Control the vibe.</p>
                 </div>
                 <div class="footer-links">


### PR DESCRIPTION
- Reduce README from 425 to 88 lines
- Use ghcr.io/lazaroagomez/beatdock:latest for pre-built image
- Keep only essential setup steps and command reference