### PR TITLE
Update youtube-source plugin to 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ plugins:
 
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.16.0"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.0"
       snapshot: false
   server:
     password: "${LAVALINK_PASSWORD:youshallnotpass}"


### PR DESCRIPTION
Version 1.16.0 of the youtube-plugin no longer works, so updated the example `application.yml` to use 1.18.0.

Not sure if you have a way to notify that this is something people need to update manually

Been running it with this updated youtube-plugin myself today and it's working great

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Docker deployment example to reference the newer YouTube plugin version in the configuration snippet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->