### PR TITLE
Automate YouTube poToken refresh for full playback + autoplay (2.10.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,13 @@ LAVALINK_PASSWORD=youshallnotpass
 # Example: PUBLIC_NODE_HOST_ALLOWLIST=node.example.com,*.trusted-lavalink.net
 #PUBLIC_NODE_HOST_ALLOWLIST=
 
+# --- YouTube poToken auto-refresh (restores non-music videos + autoplay/RD mixes) ---
+# Only used by the self-hosted Docker stack (bgutil-provider + pot-refresher services).
+# How often (seconds) the pot-refresher mints a fresh poToken and pushes it to Lavalink.
+# poTokens can expire in ~12h; the default re-pushes well within that and also recovers
+# playback after a Lavalink restart. Lower = faster restart recovery, negligible extra load.
+#POT_REFRESH_INTERVAL=1800
+
 # Optional: Language Settings
 #DEFAULT_LANGUAGE=en
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to BeatDock are documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [2.10.0] - 2026-07-06
+
+### Added
+- Automated, credential-free YouTube **poToken** refresh for the self-hosted Docker stack.
+  Two new services — `bgutil-provider` (mints the token on the host's own IP) and
+  `pot-refresher` (pushes it to Lavalink's `POST /youtube` hot-swap route every
+  `POT_REFRESH_INTERVAL` seconds) — restore playback of non-music videos and autoplay/RD-mix
+  recommendations without any Google account, API key, or manual token pasting
+- `POT_REFRESH_INTERVAL` environment variable to tune the refresh cadence (default: 1800s)
+
+### Changed
+- Lavalink `youtube` clients are now `MUSIC, WEB, WEBEMBEDDED, ANDROID_VR`. The `WEB` client
+  (backed by the auto-refreshed poToken) handles arbitrary videos and RD mixes; dropped
+  `TVHTML5_SIMPLY`, which triggered YouTube's "Sign in to confirm you're not a bot" detection
+
+### Fixed
+- Non-music videos (film/movie clips) that failed with "This video is not available" now play
+- Autoplay no longer silently stops on tracks whose RD mix only `ANDROID_VR` could not resolve
+  ("Could not find tracks from mix")
+
 ## [2.9.0] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -204,6 +204,8 @@ Playing arbitrary (non-music) videos and autoplay/RD-mix recommendations require
 
 Music keeps working through the `MUSIC`/`ANDROID_VR` clients even if the refresher is temporarily down. Age-restricted videos may still be unavailable.
 
+> **Note:** this only applies to the **self-hosted** stack. If BeatDock connects to public Lavalink nodes (no `LAVALINK_HOST` set), tokens are managed by each node's operator, so the `bgutil-provider` and `pot-refresher` services are not used and non-music playback depends on the node.
+
 ### Option B: Deploy from Source
 
 ```bash
@@ -224,6 +226,8 @@ docker compose up -d
 ### No Self-Hosted Lavalink Required
 
 BeatDock can run **without a self-hosted Lavalink server**. If `LAVALINK_HOST`, `LAVALINK_PORT`, and `LAVALINK_PASSWORD` are not set, the bot automatically fetches free public Lavalink v4 servers and connects to one. User search queries and track requests are sent to the selected public node. Set `PUBLIC_NODE_HOST_ALLOWLIST` if you only trust specific public Lavalink hosts.
+
+On public nodes the [YouTube poToken auto-refresh](#youtube-potoken-auto-refresh) does not apply: each node manages its own tokens, so whether non-music videos and autoplay mixes play depends on that node's setup.
 
 To use public servers, simply comment out the Lavalink variables in your `.env`:
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ services:
   pot-refresher:
     container_name: beatdock-pot-refresher
     image: alpine:3
+    init: true
     depends_on:
       lavalink:
         condition: service_healthy
@@ -119,7 +120,13 @@ services:
     networks:
       - beatdock-network
     volumes:
-      - ./scripts/pot-refresher.sh:/pot-refresher.sh:ro
+      # Long syntax: fail loudly if the script is missing instead of creating a junk dir.
+      - type: bind
+        source: ./scripts/pot-refresher.sh
+        target: /pot-refresher.sh
+        read_only: true
+        bind:
+          create_host_path: false
     environment:
       - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
       - POT_REFRESH_INTERVAL=${POT_REFRESH_INTERVAL:-1800}

--- a/README.md
+++ b/README.md
@@ -99,6 +99,32 @@ services:
       retries: 5
       start_period: 30s
 
+  # Mints the YouTube poToken on your own IP (credential-free). See "YouTube poToken auto-refresh".
+  bgutil-provider:
+    container_name: beatdock-bgutil
+    image: brainicism/bgutil-ytdlp-pot-provider:1.3.1
+    init: true
+    networks:
+      - beatdock-network
+
+  # Pushes a fresh poToken to Lavalink's POST /youtube hot-swap route on a loop.
+  pot-refresher:
+    container_name: beatdock-pot-refresher
+    image: alpine:3
+    depends_on:
+      lavalink:
+        condition: service_healthy
+      bgutil-provider:
+        condition: service_started
+    networks:
+      - beatdock-network
+    volumes:
+      - ./scripts/pot-refresher.sh:/pot-refresher.sh:ro
+    environment:
+      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
+      - POT_REFRESH_INTERVAL=${POT_REFRESH_INTERVAL:-1800}
+    command: sh -c "apk add --no-cache curl jq >/dev/null && exec sh /pot-refresher.sh"
+
 networks:
   beatdock-network:
     name: beatdock_network
@@ -120,11 +146,12 @@ plugins:
     clients:
       - MUSIC
       - WEB
+      - WEBEMBEDDED
       - ANDROID_VR
 
 lavalink:
   plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.16.0"
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.18.1"
       snapshot: false
   server:
     password: "${LAVALINK_PASSWORD:youshallnotpass}"
@@ -151,11 +178,24 @@ logging:
     lavalink: INFO
 ```
 
-**5. Deploy:**
+**5. Add the poToken refresher script:**
+
+Download [`scripts/pot-refresher.sh`](scripts/pot-refresher.sh) into a `scripts/` folder next to your `docker-compose.yml`. It mints a fresh YouTube poToken and hot-pushes it to Lavalink (see [YouTube poToken auto-refresh](#youtube-potoken-auto-refresh)).
+
+**6. Deploy:**
 
 ```bash
 docker compose up -d
 ```
+
+### YouTube poToken auto-refresh
+
+Playing arbitrary (non-music) videos and autoplay/RD-mix recommendations requires YouTube's `WEB` client, which needs a short-lived **poToken**. BeatDock keeps this fully automated and **credential-free** — no Google account, no API key, no manual pasting:
+
+- **`bgutil-provider`** mints a `{poToken, visitorData}` pair on your server's own IP.
+- **`pot-refresher`** pushes it to Lavalink's `POST /youtube` hot-swap route (no restart) and re-pushes every `POT_REFRESH_INTERVAL` seconds (default `1800`), covering both token expiry and Lavalink restarts.
+
+Music keeps working through the `MUSIC`/`ANDROID_VR` clients even if the refresher is temporarily down. Age-restricted videos may still be unavailable.
 
 ### Option B: Deploy from Source
 

--- a/application.yml
+++ b/application.yml
@@ -13,9 +13,10 @@ plugins:
     allowDirectVideoIds: true
     allowDirectPlaylistIds: true
     clients:
-      - MUSIC
-      - ANDROID_VR
-      - TVHTML5_SIMPLY
+      - MUSIC          # ytmsearch / music catalog
+      - WEB            # arbitrary videos + RD mixes (needs poToken, pushed by pot-refresher)
+      - WEBEMBEDDED    # embed / age-limited fallback (also uses poToken)
+      - ANDROID_VR     # credential-free safety net if the poToken is momentarily unavailable
   lavasrc:
     providers:
       - "ytsearch:\"%ISRC%\""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,43 @@ services:
       retries: 5
       start_period: 30s
 
+  # Mints a YouTube poToken (credential-free, same egress IP as Lavalink). Internal-only.
+  bgutil-provider:
+    container_name: beatdock-bgutil
+    image: brainicism/bgutil-ytdlp-pot-provider:1.3.1
+    init: true
+    networks:
+      - beatdock-network
+    restart: unless-stopped
+    mem_limit: 384m
+    pids_limit: 256
+    cpus: "1.0"
+    logging: *default-logging
+
+  # Loops: mint {poToken, visitorData} from bgutil -> push to Lavalink's POST /youtube
+  # hot-swap route (no restart). Restores non-music videos + autoplay/RD mixes on the WEB client.
+  pot-refresher:
+    container_name: beatdock-pot-refresher
+    image: alpine:3
+    depends_on:
+      lavalink:
+        condition: service_healthy
+      bgutil-provider:
+        condition: service_started
+    networks:
+      - beatdock-network
+    volumes:
+      - ./scripts/pot-refresher.sh:/pot-refresher.sh:ro
+    environment:
+      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
+      - POT_REFRESH_INTERVAL=${POT_REFRESH_INTERVAL:-1800}
+    command: sh -c "apk add --no-cache curl jq >/dev/null && exec sh /pot-refresher.sh"
+    restart: unless-stopped
+    mem_limit: 64m
+    pids_limit: 64
+    cpus: "0.5"
+    logging: *default-logging
+
 networks:
   beatdock-network:
     name: beatdock_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,7 @@ services:
   pot-refresher:
     container_name: beatdock-pot-refresher
     image: alpine:3
+    init: true
     depends_on:
       lavalink:
         condition: service_healthy
@@ -84,7 +85,13 @@ services:
     networks:
       - beatdock-network
     volumes:
-      - ./scripts/pot-refresher.sh:/pot-refresher.sh:ro
+      # Long syntax: fail loudly if the script is missing instead of creating a junk dir.
+      - type: bind
+        source: ./scripts/pot-refresher.sh
+        target: /pot-refresher.sh
+        read_only: true
+        bind:
+          create_host_path: false
     environment:
       - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
       - POT_REFRESH_INTERVAL=${POT_REFRESH_INTERVAL:-1800}

--- a/docs/index.html
+++ b/docs/index.html
@@ -57,7 +57,7 @@
         </a>
       </div>
       <div class="hero__badges">
-        <span class="badge">v2.9.0</span>
+        <span class="badge">v2.10.0</span>
         <span class="badge">Apache-2.0</span>
         <span class="badge">Docker Ready</span>
       </div>
@@ -141,6 +141,14 @@
           </div>
           <h3 class="card__title">Public Lavalink Fallback</h3>
           <p class="card__description">No self-hosted server needed. Auto-connects to free public Lavalink nodes.</p>
+        </div>
+
+        <div class="card fade-in">
+          <div class="card__icon">
+            <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"/><path d="M21 3v5h-5"/><path d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"/><path d="M8 16H3v5"/></svg>
+          </div>
+          <h3 class="card__title">YouTube Token Auto-Refresh</h3>
+          <p class="card__description">Fresh poTokens pushed to Lavalink automatically, so non-music videos and autoplay keep working. No Google account or API key. Self-hosted stacks only.</p>
         </div>
 
       </div>
@@ -283,6 +291,9 @@ DEFAULT_LANGUAGE=en
 # LAVALINK_PORT=2333
 # LAVALINK_PASSWORD=youshallnotpass
 
+# YouTube poToken refresh cadence in seconds (self-hosted stack only)
+# POT_REFRESH_INTERVAL=1800
+
 # Timeouts
 QUEUE_EMPTY_DESTROY_MS=30000
 EMPTY_CHANNEL_DESTROY_MS=60000</code></pre>
@@ -316,6 +327,7 @@ EMPTY_CHANNEL_DESTROY_MS=60000</code></pre>
                 <tr><td><code>ALLOWED_ROLES</code></td><td>—</td><td>Comma-separated role IDs to restrict access</td></tr>
                 <tr><td><code>DEFAULT_SEARCH_PLATFORM</code></td><td><code>ytmsearch</code></td><td>Default search platform</td></tr>
                 <tr><td><code>LAVALINK_PASSWORD</code></td><td><code>youshallnotpass</code></td><td>Lavalink server password</td></tr>
+                <tr><td><code>POT_REFRESH_INTERVAL</code></td><td><code>1800</code></td><td>YouTube poToken refresh cadence in seconds (self-hosted stack only)</td></tr>
                 <tr><td><code>QUEUE_EMPTY_DESTROY_MS</code></td><td><code>30000</code></td><td>Disconnect after queue empties (ms)</td></tr>
                 <tr><td><code>EMPTY_CHANNEL_DESTROY_MS</code></td><td><code>60000</code></td><td>Disconnect from empty channel (ms)</td></tr>
               </tbody>
@@ -340,10 +352,21 @@ docker compose up -d</code></pre>
           </div>
         </div>
 
-        <!-- Managing -->
+        <!-- YouTube poToken Auto-Refresh -->
         <div class="guide__block fade-in">
           <h3 class="guide__heading">
             <span class="guide__heading-number">6</span>
+            YouTube poToken Auto-Refresh
+          </h3>
+          <p class="guide__text">The self-hosted stack ships two extra services: <code>bgutil-provider</code> mints a YouTube <strong>poToken</strong> on your server's own IP, and <code>pot-refresher</code> pushes it to Lavalink's hot-swap route every 30 minutes. This keeps non-music videos and autoplay mixes playable. No Google account, no API key, no manual token pasting.</p>
+          <p class="guide__text">Download <a href="https://github.com/albertgmz/BeatDock/blob/main/scripts/pot-refresher.sh" target="_blank" rel="noopener"><code>scripts/pot-refresher.sh</code></a> into a <code>scripts/</code> folder next to your <code>docker-compose.yml</code>, and tune the cadence with <code>POT_REFRESH_INTERVAL</code> (seconds, default <code>1800</code>). Music keeps playing even if the refresher is temporarily down.</p>
+          <p class="guide__text guide__text--muted">Self-hosted Lavalink only. If BeatDock runs on public Lavalink nodes, tokens are handled by the node operator and this doesn't apply.</p>
+        </div>
+
+        <!-- Managing -->
+        <div class="guide__block fade-in">
+          <h3 class="guide__heading">
+            <span class="guide__heading-number">7</span>
             Managing the Bot
           </h3>
           <div class="guide__code">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "beatdock",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "beatdock",
-      "version": "2.9.1",
+      "version": "2.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "discord.js": "^14.26.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beatdock",
-  "version": "2.9.1",
+  "version": "2.10.0",
   "description": "A modern and efficient Discord music bot with slash commands, multi-language support, and Docker deployment.",
   "main": "src/index.js",
   "scripts": {

--- a/scripts/pot-refresher.sh
+++ b/scripts/pot-refresher.sh
@@ -9,6 +9,8 @@ set -u
 BGUTIL_URL="${BGUTIL_URL:-http://bgutil-provider:4416}"
 LAVALINK_URL="${LAVALINK_URL:-http://lavalink:2333}"
 REFRESH_INTERVAL="${POT_REFRESH_INTERVAL:-1800}"
+# Non-numeric interval would make sleep fail after a SUCCESSFUL refresh -> tight mint loop.
+[ "$REFRESH_INTERVAL" -gt 0 ] 2>/dev/null || REFRESH_INTERVAL=1800
 
 if [ -z "${LAVALINK_PASSWORD:-}" ]; then
   echo "[pot-refresher] LAVALINK_PASSWORD is required" >&2

--- a/scripts/pot-refresher.sh
+++ b/scripts/pot-refresher.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Auto-refreshes the YouTube poToken for Lavalink's youtube-source (WEB/WEBEMBEDDED).
+# Mints a fresh {poToken, visitorData} pair from the bgutil provider and pushes it to
+# Lavalink's POST /youtube route (hot-swap, no restart). Loops so it also survives token
+# expiry and Lavalink restarts. bgutil owns the fragile BotGuard logic; this is only glue.
+# ponytail: shell+curl+jq, not a Node app. add-when: bgutil field names change on a major bump.
+set -u
+
+BGUTIL_URL="${BGUTIL_URL:-http://bgutil-provider:4416}"
+LAVALINK_URL="${LAVALINK_URL:-http://lavalink:2333}"
+REFRESH_INTERVAL="${POT_REFRESH_INTERVAL:-1800}"
+
+if [ -z "${LAVALINK_PASSWORD:-}" ]; then
+  echo "[pot-refresher] LAVALINK_PASSWORD is required" >&2
+  exit 1
+fi
+
+refresh() {
+  resp=$(curl -fsS -m 30 -X POST "$BGUTIL_URL/get_pot" \
+    -H 'Content-Type: application/json' -d '{}') || return 1
+  pot=$(printf '%s' "$resp" | jq -r '.poToken // empty')
+  vd=$(printf '%s' "$resp" | jq -r '.contentBinding // empty')
+  [ -n "$pot" ] && [ -n "$vd" ] || return 1
+  # jq -nc builds the body safely (no manual escaping of token material).
+  curl -fsS -m 30 -X POST "$LAVALINK_URL/youtube" \
+    -H "Authorization: $LAVALINK_PASSWORD" \
+    -H 'Content-Type: application/json' \
+    -d "$(jq -nc --arg p "$pot" --arg v "$vd" '{poToken:$p, visitorData:$v}')" || return 1
+  echo "[pot-refresher] pushed fresh poToken + visitorData to Lavalink"
+}
+
+echo "[pot-refresher] starting; interval=${REFRESH_INTERVAL}s"
+while true; do
+  if refresh; then
+    sleep "$REFRESH_INTERVAL"
+  else
+    echo "[pot-refresher] refresh failed; keeping last-known-good, retry in 30s" >&2
+    sleep 30
+  fi
+done


### PR DESCRIPTION
Fixes #151. Supersedes #150.

Bumping the plugin alone brings music back, but non-music videos and autoplay mixes still need a poToken on the WEB client. This automates that, no Google account or API key needed:

- `bgutil-provider` mints a poToken/visitorData pair on your own IP
- `pot-refresher` pushes it to Lavalink's `POST /youtube` hot-swap route every 30 min, so it survives token expiry and Lavalink restarts

Also bumps youtube-plugin to 1.18.1 and swaps `TVHTML5_SIMPLY` for `WEB`/`WEBEMBEDDED`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic, credential-free YouTube poToken auto-refresh for self-hosted Docker deployments.
  - Introduced a `POT_REFRESH_INTERVAL` option (default 1800s) to control refresh cadence.
  - Expanded supported Lavalink YouTube clients for broader playback compatibility.
- **Bug Fixes**
  - Fixed non-music YouTube videos failing with “This video is not available.”
  - Fixed autoplay stopping when RD-mix tracks couldn’t be resolved.
- **Documentation**
  - Updated README and setup guide with a new YouTube poToken auto-refresh section and compose instructions.
  - Updated env/config examples and release information for version 2.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->